### PR TITLE
expand-all 属性失效问题解决

### DIFF
--- a/src/models/data/row.ts
+++ b/src/models/data/row.ts
@@ -160,7 +160,7 @@ export class Row {
     const el = options.endLabel || Variables.key.end;
 
     Object.assign(this.options, { sl, el });
-    this.__isExpand = this.options.isExpand || true;
+    this.__isExpand = data?.isExpand ?? options.isExpand ?? true;
 
     // const that = this;
     // this.__data = new Proxy(data, {


### PR DESCRIPTION
更改了展开的判断逻辑，修复全部展开属性失效的问题。并允许在data中设置isExpand的值来修改默认展开状态